### PR TITLE
Add behavioural stress (TGEMO_00210)

### DIFF
--- a/TGEMO.OWL
+++ b/TGEMO.OWL
@@ -1128,7 +1128,22 @@ This zQ175DN KI allele is the same design as the zQ175 KI allele (Stock No. 0274
         <oboInOwl:hasExactSynonym>zQ175 neo-deleted knock-in</oboInOwl:hasExactSynonym>
         <rdfs:label xml:lang="en">zQ175DN KI</rdfs:label>
     </owl:Class>
-    
+
+
+
+    <!-- http://gemma.msl.ubc.ca/ont/TGEMO_00210 -->
+
+    <owl:Class rdf:about="http://gemma.msl.ubc.ca/ont/TGEMO_00210">
+        <rdfs:subClassOf rdf:resource="http://www.ebi.ac.uk/efo/EFO_0000470"/>
+        <obo:IAO_0000115>A behavioural or psychological stressor applied to an experimental subject. Combines with severity modifiers (mild / moderate / severe), temporal-pattern modifiers (acute / chronic), and `delivered for duration` for the experimental time course. Parent EFO:0000470 is provisional; the concept is a stressor / protocol rather than a treatment effect and may move to a more appropriate parent in a future revision.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym>behavioral stress</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>psychological stress</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasRelatedSynonym>stress</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>stressor</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym>stressful experience</oboInOwl:hasRelatedSynonym>
+        <rdfs:label xml:lang="en">behavioural stress</rdfs:label>
+    </owl:Class>
+
 
 
     <!-- http://gemma.msl.ubc.ca/ont/TGEMO:00103 -->


### PR DESCRIPTION
## Summary

Adds `TGEMO_00210` — **behavioural stress** — as a subclass of `EFO:0000470` (environmental stress).

Motivation: Paul 2026-06-12 review of GSE193284 (chronic mild stress / CMS) surfaced that the curation agent had no canonical URI for the behavioural-stress concept. The existing curation pattern was to bind `EFO:0000470` directly with the typed phrase as a label, but `EFO:0000470`'s canonical label is "environmental stress" — a different concept (environmental factors like thermal, chemical, etc.). Behavioural / psychological stress is a distinct kind of stressor that deserves its own term.

## What the new term enables

With this term in place, a CMS-shape FV (the canonical example) can be emitted as compositional decomposition rather than as a compound subject:

| typed FV label | emitted statements |
|---|---|
| `Chronic mild stress` | `behavioural stress (TGEMO_00210) + has modifier + mild (HP:0012825)` <br> `behavioural stress + has modifier + chronic (HP:0011010)` <br> `behavioural stress + delivered for duration + "3 weeks"` (free text) |
| `Chronic mild stress + Phloretin` | above three, plus `Phloretin (CHEBI:17276) + delivered at dose + "20 mg/kg"` |

This pattern reuses existing HPO severity / chronicity terms for the modifier slots and keeps the experimental-duration as a separate `delivered for duration` statement. Conceptual chronicity ("this is a chronic stress paradigm") is queryable separately from the specific experimental window ("the protocol ran 3 weeks") — they answer different downstream questions.

## Synonyms — `stress` is RELATED not EXACT

`stress` alone is ambiguous (environmental thermal, oxidative, mechanical, cellular, behavioural all exist) and is tagged as `hasRelatedSynonym`, not `hasExactSynonym`. Only `behavioral stress` (US spelling) and `psychological stress` are tagged exact — they refer to the same concept directly. `stressor` and `stressful experience` are also related.

## Provisional parent

`EFO:0000470` (environmental stress) is provisional per Paul. Strictly speaking behavioural stress is a stressor / protocol type, not a treatment effect, and a more appropriate parent may be chosen in a future revision. The provisional note is preserved in the definition.

## Field summary

| field | value |
|---|---|
| URI | `http://gemma.msl.ubc.ca/ont/TGEMO_00210` |
| label | behavioural stress |
| parent | EFO:0000470 (environmental stress) — provisional |
| definition | A behavioural or psychological stressor applied to an experimental subject. Combines with severity modifiers (mild / moderate / severe), temporal-pattern modifiers (acute / chronic), and `delivered for duration` for the experimental time course. |
| exact synonyms | behavioral stress · psychological stress |
| related synonyms | stress · stressor · stressful experience |

## Coordinated changes

Pairs with these PavlidisLab/gemma-curation-agents commits:

- `0917f5d` — adds compositional-decomposition rule to `curator_wisdom.md` + D17 orchestrator-checklist invariant
- `e1e5e98` — rewrites `column_annotator.py` Example A to teach the decomposition pattern (was teaching the wrong `Chronic mild stress → EFO:0000470` direct binding)
- `8cae6ff` — refines the wisdom-doc decomposition example to use `behavioural stress` specifically (not bare `stress`) per Paul's clarification that `stress` is too broad; also adds the general rule "existing curation is a signal, not authority"

Once this PR lands and Gemma reloads the ontology, those agent-side rules ground their canonical URIs.
