### PR TITLE
add targeted towards as TGEMO_00215

### DIFF
--- a/TGEMO.OWL
+++ b/TGEMO.OWL
@@ -230,6 +230,19 @@
     
 
 
+    <!-- http://gemma.msl.ubc.ca/ont/TGEMO_00215 -->
+
+    <owl:ObjectProperty rdf:about="http://gemma.msl.ubc.ca/ont/TGEMO_00215">
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000086"/>
+        <obo:IAO_0000115>Indicates that the Subject (a perturbed gene) was altered only within the cell type or tissue named by the Object, rather than throughout the organism. Used for conditional / Cre-lox knockouts, cell-type-specific knockdowns and tissue-specific overexpression. The Object is a Cell Ontology (CL) cell type or an UBERON tissue. Example: Sipr1 targeted towards astrocyte (CL:0000127), from a study of an astrocyte-specific S1P1 knockout.</obo:IAO_0000115>
+        <obo:IAO_0000232>The target of the perturbation is INDEPENDENT of the cell type the experiment profiled; the two are frequently the same and must still be stated separately, because a perturbation restricted to one population is routinely assayed in another. Minted in TGEMO because no existing relation carries this meaning: RO:0002503 (&quot;towards&quot;) relates a relational quality to what it is a quality toward, and RO:0001025 (&quot;located in&quot;) would assert the gene&apos;s own anatomical location rather than where the alteration acts. TGEMO:00183 (&quot;delivered to&quot;) is the nearest sibling and deliberately not reused: it presupposes an administration event at a site, which a germline conditional allele does not have.</obo:IAO_0000232>
+        <oboInOwl:hasExactSynonym>restricted to cell type</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">targeted towards</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+
     <!-- http://gemma.msl.ubc.ca/ont/TGEMO_00183 -->
 
     <owl:ObjectProperty rdf:about="http://gemma.msl.ubc.ca/ont/TGEMO_00183">


### PR DESCRIPTION
Adds one object property: **`targeted towards`** — `http://gemma.msl.ubc.ca/ont/TGEMO_00215`, `subPropertyOf RO_0000086`, matching the seven existing TGEMO object properties.

A cell-type/tissue-**targeted** perturbation (conditional / Cre-lox KO, cell-type-specific knockdown, tissue-specific overexpression) is restricted to the cell type or tissue named by the object.

- **subject** = the perturbed gene
- **object** = a Cell Ontology cell type or an UBERON tissue

Worked shape: `S1pr1 + targeted towards + astrocyte [CL_0000127]`, from a study of an astrocyte-specific S1P1 knockout. The perturbation's target is independent of the cell type the experiment *profiled* — the two are frequently the same and must still be stated separately, because a perturbation restricted to one population is routinely assayed in another.

Conditional knockouts are the broad case: a floxed allele plus a tissue-specific Cre driver is a perturbation restricted to wherever that driver is active, and today the tissue is either lost in a free-text modifier or implied by the allele string in the label.

### Why mint rather than reuse

| candidate | why not |
|---|---|
| `RO_0002503` "towards" | relates a relational *quality* to what it is a quality toward |
| `RO_0001025` "located in" | would assert the gene's own anatomical location rather than where the alteration acts |
| `TGEMO_00183` "delivered to" | presupposes an administration event at a site, which a germline conditional allele does not have |

### Why 00215 and not 00214

`TGEMO_00214` was minted in 6536c41 and reverted in b8c2f88, and that reversal is on `master` — the id is publicly retired and is not reused.

### Impact

The predicate has been proposed by the curation agent across 18 experiments, 8 of which reached a structured apply path. Until now its URI was `null`, so applying one produced a statement that failed the curation UI's URI-keyed predicate allow-list and blocked the commit, with the label absent from the picker and no in-UI way to repair it. Once this merges and Gemma redeploys, `sync_predicates_to_ui.py` picks the term up and those apply paths work like any other.

`make check` was not run — no `robot.jar` in the checkout. The file parses as XML and the class shape matches its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
